### PR TITLE
Add Main Menu Screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,6 @@
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
 </head>
 <body>
-    <script src="main.js"></script>
+    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/logic/menuLogic.js
+++ b/logic/menuLogic.js
@@ -1,0 +1,9 @@
+export function createMenuButton(scene, x, y, label, callback) {
+    const button = scene.add.text(x, y, label, { fontSize: '24px', backgroundColor: '#222', color: '#fff', padding: { x: 10, y: 5 } })
+        .setInteractive({ useHandCursor: true })
+        .on('pointerdown', callback)
+        .on('pointerover', () => button.setStyle({ backgroundColor: '#555' }))
+        .on('pointerout', () => button.setStyle({ backgroundColor: '#222' }));
+    button.setOrigin(0.5);
+    return button;
+}

--- a/main.js
+++ b/main.js
@@ -1,24 +1,11 @@
+import MainMenu from './ui/MainMenu.js';
+import MainScene from './scenes/MainScene.js';
+
 const config = {
     type: Phaser.AUTO,
     width: 800,
     height: 600,
-    scene: {
-        preload: preload,
-        create: create,
-        update: update
-    }
+    scene: [MainMenu, MainScene]
 };
 
-const game = new Phaser.Game(config);
-
-function preload() {
-    // Preload assets here
-}
-
-function create() {
-    // Initialize game objects here
-}
-
-function update() {
-    // Game loop logic here
-}
+new Phaser.Game(config);

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -1,0 +1,18 @@
+export default class MainScene extends Phaser.Scene {
+    constructor() {
+        super('MainScene');
+    }
+
+    preload() {
+        // Preload assets for the main game here
+    }
+
+    create() {
+        // Placeholder game text
+        this.add.text(400, 300, 'Game Scene', { fontSize: '32px', color: '#FFFFFF' }).setOrigin(0.5);
+    }
+
+    update() {
+        // Main game update logic would go here
+    }
+}

--- a/ui/MainMenu.js
+++ b/ui/MainMenu.js
@@ -1,0 +1,25 @@
+import { createMenuButton } from '../logic/menuLogic.js';
+import MainScene from '../scenes/MainScene.js';
+
+export default class MainMenu extends Phaser.Scene {
+    constructor() {
+        super('MainMenu');
+    }
+
+    create() {
+        const { width, height } = this.scale;
+        this.add.text(width / 2, height / 2 - 100, 'Stellar Fleet 2D', { fontSize: '32px', color: '#fff' }).setOrigin(0.5);
+
+        createMenuButton(this, width / 2, height / 2, 'New Game', () => {
+            this.scene.start('MainScene');
+        });
+
+        createMenuButton(this, width / 2, height / 2 + 60, 'Quit', () => {
+            if (window.close) {
+                window.close();
+            } else {
+                this.add.text(width / 2, height / 2 + 120, 'Merci d\'avoir joué!', { fontSize: '18px', color: '#fff' }).setOrigin(0.5);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add UI folder with MainMenu scene
- add simple button helper
- create main game scene placeholder
- update main.js to use modules and start with menu scene
- load main.js as module in index.html

## Testing
- `node --check main.js`
- `node --check scenes/MainScene.js`
- `node --check ui/MainMenu.js`
- `node --check logic/menuLogic.js`

------
https://chatgpt.com/codex/tasks/task_e_6869853100d4832590d98b560a076376