### PR TITLE
Adapt interface for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
 </head>
 <body>
+    <div id="game-container"></div>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -3,9 +3,19 @@ import MainScene from './scenes/MainScene.js';
 
 const config = {
     type: Phaser.AUTO,
-    width: 800,
-    height: 600,
+    parent: 'game-container',
+    width: window.innerWidth,
+    height: window.innerHeight,
+    scale: {
+        mode: Phaser.Scale.RESIZE,
+        autoCenter: Phaser.Scale.CENTER_BOTH
+    },
     scene: [MainMenu, MainScene]
 };
 
-new Phaser.Game(config);
+const game = new Phaser.Game(config);
+
+window.addEventListener('resize', () => {
+    game.scale.resize(window.innerWidth, window.innerHeight);
+});
+

--- a/style.css
+++ b/style.css
@@ -1,8 +1,15 @@
-body {
+html, body {
     margin: 0;
     padding: 0;
+    height: 100%;
     background-color: #000;
     color: #fff;
+}
+
+#game-container {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
 }
 
 canvas {


### PR DESCRIPTION
## Summary
- add a `game-container` div so the game can scale to the viewport
- style the container and page to fill the entire screen
- configure Phaser to resize with the screen and handle orientation changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686986f2a59083258f96f00f68e62e20