### PR TITLE
Add responsive Phaser UI

### DIFF
--- a/logic/menuLogic.js
+++ b/logic/menuLogic.js
@@ -1,19 +1,47 @@
-export function createMenuButton(scene, x, y, label, callback) {
+/**
+ * Clamp a value between a minimum and maximum.
+ * @param {number} value - value to clamp
+ * @param {number} min - minimum value
+ * @param {number} max - maximum value
+ */
+export function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Utility creating a menu button. Font size can be adjusted after creation
+ * to react to screen resizing.
+ *
+ * @param {Phaser.Scene} scene - scene where the button is created
+ * @param {number} x - horizontal position
+ * @param {number} y - vertical position
+ * @param {string} label - button label
+ * @param {Function} callback - callback executed on click
+ * @param {number} fontSize - initial font size in pixels
+ */
+export function createMenuButton(scene, x, y, label, callback, fontSize = 28) {
     const style = {
         fontFamily: 'Orbitron',
-        fontSize: '28px',
+        fontSize: `${fontSize}px`,
         backgroundColor: 'rgba(0, 0, 0, 0.5)',
         color: '#0ff',
         padding: { x: 20, y: 10 },
         stroke: '#0ff',
         strokeThickness: 2
     };
+
     const button = scene.add
         .text(x, y, label, style)
         .setInteractive({ useHandCursor: true })
         .on('pointerdown', callback)
-        .on('pointerover', () => button.setStyle({ backgroundColor: 'rgba(0, 255, 255, 0.3)' }))
-        .on('pointerout', () => button.setStyle({ backgroundColor: 'rgba(0, 0, 0, 0.5)' }));
+        .on('pointerover', () =>
+            button.setStyle({ backgroundColor: 'rgba(0, 255, 255, 0.3)' })
+        )
+        .on('pointerout', () =>
+            button.setStyle({ backgroundColor: 'rgba(0, 0, 0, 0.5)' })
+        );
+
     button.setOrigin(0.5);
+
     return button;
 }

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -8,8 +8,27 @@ export default class MainScene extends Phaser.Scene {
     }
 
     create() {
-        // Placeholder game text
-        this.add.text(400, 300, 'Game Scene', { fontSize: '32px', color: '#FFFFFF' }).setOrigin(0.5);
+        const { width, height } = this.scale;
+
+        this.infoText = this.add
+            .text(0, 0, 'Game Scene', {
+                fontFamily: 'Orbitron',
+                color: '#FFFFFF',
+                stroke: '#0ff',
+                strokeThickness: 2,
+            })
+            .setOrigin(0.5);
+
+        this.resizeUI({ width, height });
+
+        this.scale.on('resize', this.resizeUI, this);
+    }
+
+    resizeUI(gameSize) {
+        const { width, height } = gameSize;
+        const size = Math.max(20, Math.min(48, height * 0.05));
+        this.infoText.setFontSize(size);
+        this.infoText.setPosition(width / 2, height / 2);
     }
 
     update() {


### PR DESCRIPTION
## Summary
- implement clamp and menu button utility
- add dynamic layout in `MainMenu` with responsive resize handler
- adjust `MainScene` text sizing on resize

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869990eac348325acdbe4268ab9673d