### PR TITLE
Improve display scaling for retina screens

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,11 +6,13 @@ const config = {
     parent: 'game-container',
     width: window.innerWidth,
     height: window.innerHeight,
+    resolution: window.devicePixelRatio || 1,
+    pixelArt: true,
     scale: {
-        mode: Phaser.Scale.RESIZE,
-        autoCenter: Phaser.Scale.CENTER_BOTH
+        mode: Phaser.Scale.FIT,
+        autoCenter: Phaser.Scale.CENTER_BOTH,
     },
-    scene: [MainMenu, MainScene]
+    scene: [MainMenu, MainScene],
 };
 
 const game = new Phaser.Game(config);

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -4,7 +4,8 @@ export default class MainScene extends Phaser.Scene {
     }
 
     preload() {
-        // Preload assets for the main game here
+        // Simple image to demonstrate crisp rendering
+        this.load.image('logo', 'assets/main menu.png');
     }
 
     create() {
@@ -18,6 +19,9 @@ export default class MainScene extends Phaser.Scene {
                 strokeThickness: 2,
             })
             .setOrigin(0.5);
+
+        // Centered sprite for testing high DPI rendering
+        this.logo = this.add.image(width / 2, height / 2 - 100, 'logo').setOrigin(0.5);
 
         this.resizeUI({ width, height });
 

--- a/style.css
+++ b/style.css
@@ -18,4 +18,5 @@ html, body {
 canvas {
     display: block;
     margin: 0 auto;
+    image-rendering: pixelated;
 }


### PR DESCRIPTION
## Summary
- scale game with `Phaser.Scale.FIT` and center everything
- adapt resolution using `window.devicePixelRatio`
- disable antialiasing with `pixelArt: true`
- show a simple centered sprite in `MainScene`
- force `image-rendering: pixelated` on the canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68699aebb8848325878aae99899901c5