### PR TITLE
Add new empire setup scene

### DIFF
--- a/dataclasses/EmpireSetup.js
+++ b/dataclasses/EmpireSetup.js
@@ -1,0 +1,8 @@
+export default class EmpireSetup {
+    constructor() {
+        this.empireName = '';
+        this.civilization = '';
+        this.leaderName = '';
+        this.leader = '';
+    }
+}

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 import MainMenu from './ui/MainMenu.js';
+import SetupScene from './scenes/SetupScene.js';
 import MainScene from './scenes/MainScene.js';
 
 const config = {
@@ -12,7 +13,10 @@ const config = {
         mode: Phaser.Scale.FIT,
         autoCenter: Phaser.Scale.CENTER_BOTH,
     },
-    scene: [MainMenu, MainScene],
+    dom: {
+        createContainer: true,
+    },
+    scene: [MainMenu, SetupScene, MainScene],
 };
 
 const game = new Phaser.Game(config);

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -8,11 +8,15 @@ export default class MainScene extends Phaser.Scene {
         this.load.image('logo', 'assets/main menu.png');
     }
 
-    create() {
+    create(data) {
         const { width, height } = this.scale;
+        this.setupData = data?.setupData;
 
+        const title = this.setupData?.empireName
+            ? `Empire: ${this.setupData.empireName}`
+            : 'Game Scene';
         this.infoText = this.add
-            .text(0, 0, 'Game Scene', {
+            .text(0, 0, title, {
                 fontFamily: 'Orbitron',
                 color: '#FFFFFF',
                 stroke: '#0ff',

--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -1,0 +1,75 @@
+import EmpireSetup from '../dataclasses/EmpireSetup.js';
+
+export default class SetupScene extends Phaser.Scene {
+    constructor() {
+        super('SetupScene');
+    }
+
+    preload() {
+        this.load.image('menuBg', 'assets/main menu.png');
+    }
+
+    create() {
+        const { width, height } = this.scale;
+
+        this.bg = this.add.image(0, 0, 'menuBg').setOrigin(0).setDisplaySize(width, height);
+
+        this.setupData = new EmpireSetup();
+
+        const formHtml = `
+            <div class="form-container">
+                <div>
+                    <label>Empire Name:<br><input type="text" id="empireName" /></label>
+                </div>
+                <div>
+                    <label>Civilization:<br>
+                        <select id="civilization">
+                            <option value="Terran">Terran</option>
+                            <option value="Martian">Martian</option>
+                            <option value="Alien">Alien</option>
+                        </select>
+                    </label>
+                </div>
+                <div>
+                    <label>Leader Name:<br><input type="text" id="leaderName" /></label>
+                </div>
+                <div>
+                    <label>Leader Type:<br>
+                        <select id="leader">
+                            <option value="Admiral">Admiral</option>
+                            <option value="Overlord">Overlord</option>
+                            <option value="Commander">Commander</option>
+                        </select>
+                    </label>
+                </div>
+                <button id="startBtn">Start Game</button>
+            </div>`;
+
+        this.form = this.add.dom(width / 2, height / 2).createFromHTML(formHtml);
+
+        const startBtn = this.form.getChildByID('startBtn');
+        startBtn.addEventListener('click', () => {
+            this.setupData.empireName = this.form.getChildByID('empireName').value;
+            this.setupData.civilization = this.form.getChildByID('civilization').value;
+            this.setupData.leaderName = this.form.getChildByID('leaderName').value;
+            this.setupData.leader = this.form.getChildByID('leader').value;
+            this.scene.start('MainScene', { setupData: this.setupData });
+        });
+
+        this.scale.on('resize', this.resizeUI, this);
+    }
+
+    resizeUI(gameSize) {
+        const { width, height } = gameSize;
+        if (this.bg) {
+            this.bg.setDisplaySize(width, height);
+        }
+        if (this.form) {
+            this.form.setPosition(width / 2, height / 2);
+        }
+    }
+
+    shutdown() {
+        this.scale.off('resize', this.resizeUI, this);
+    }
+}

--- a/style.css
+++ b/style.css
@@ -20,3 +20,33 @@ canvas {
     margin: 0 auto;
     image-rendering: pixelated;
 }
+
+.form-container {
+    background: rgba(0, 0, 0, 0.6);
+    padding: 20px;
+    border: 2px solid #0ff;
+    color: #0ff;
+    font-family: 'Orbitron', sans-serif;
+}
+.form-container label {
+    display: block;
+    margin-bottom: 8px;
+}
+.form-container input,
+.form-container select {
+    width: 100%;
+    margin-top: 4px;
+    margin-bottom: 12px;
+    background: #000;
+    color: #0ff;
+    border: 1px solid #0ff;
+}
+.form-container button {
+    display: block;
+    margin: 0 auto;
+    padding: 8px 20px;
+    background: #001020;
+    color: #0ff;
+    border: 1px solid #0ff;
+    cursor: pointer;
+}

--- a/ui/MainMenu.js
+++ b/ui/MainMenu.js
@@ -1,5 +1,4 @@
 import { createMenuButton, clamp } from '../logic/menuLogic.js';
-import MainScene from '../scenes/MainScene.js';
 
 // Ratios and limits for responsive layout
 const TITLE_RATIO = 0.08;
@@ -19,7 +18,7 @@ export default class MainMenu extends Phaser.Scene {
     }
 
     preload() {
-        // No external assets used for UI, the menu background is drawn with shapes
+        this.load.image('menuBg', 'assets/main menu.png');
     }
 
     create() {
@@ -28,8 +27,8 @@ export default class MainMenu extends Phaser.Scene {
         // container grouping all UI elements for easy resizing
         this.uiContainer = this.add.container(0, 0);
 
-        // background rectangle simulating a menu image
-        this.bg = this.add.rectangle(0, 0, width, height, 0x001020, 0.9).setOrigin(0);
+        // background image
+        this.bgImage = this.add.image(0, 0, 'menuBg').setOrigin(0).setDisplaySize(width, height);
 
         // placeholder logo
         this.logo = this.add
@@ -47,7 +46,6 @@ export default class MainMenu extends Phaser.Scene {
             .setOrigin(0.5);
 
         this.playButton = createMenuButton(this, 0, 0, 'New Game', () => {
-            this.scene.start('MainScene');
         });
 
         this.quitButton = createMenuButton(this, 0, 0, 'Quit', () => {
@@ -63,7 +61,7 @@ export default class MainMenu extends Phaser.Scene {
             }
         });
 
-        this.uiContainer.add([this.bg, this.logo, this.titleText, this.playButton, this.quitButton]);
+        this.uiContainer.add([this.bgImage, this.logo, this.titleText, this.playButton, this.quitButton]);
 
         // fade in effect
         this.uiContainer.setAlpha(0);
@@ -79,7 +77,7 @@ export default class MainMenu extends Phaser.Scene {
         const { width, height } = gameSize;
         const min = Math.min(width, height);
 
-        this.bg.setSize(width, height);
+        this.bgImage.setDisplaySize(width, height);
 
         const titleSize = clamp(height * TITLE_RATIO, MIN_TITLE, MAX_TITLE);
         this.titleText.setFontSize(titleSize);


### PR DESCRIPTION
## Summary
- show menu background image
- add SetupScene for naming the empire and selecting leader options
- enable DOM overlay for form controls
- display empire name in MainScene

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Stellar-Fleet-2D/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6869a7f2f360832587524488bbd47e7c