### PR TITLE
Improve dark theme setup screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Stellar Fleet 2D</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&family=Rajdhani:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <!-- Phaser 3 via CDN -->
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>

--- a/logic/menuLogic.js
+++ b/logic/menuLogic.js
@@ -24,9 +24,9 @@ export function createMenuButton(scene, x, y, label, callback, fontSize = 28) {
         fontFamily: 'Orbitron',
         fontSize: `${fontSize}px`,
         backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        color: '#0ff',
+        color: '#00ffe0',
         padding: { x: 20, y: 10 },
-        stroke: '#0ff',
+        stroke: '#00ffe0',
         strokeThickness: 2
     };
 

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -19,7 +19,7 @@ export default class MainScene extends Phaser.Scene {
             .text(0, 0, title, {
                 fontFamily: 'Orbitron',
                 color: '#FFFFFF',
-                stroke: '#0ff',
+                stroke: '#00ffe0',
                 strokeThickness: 2,
             })
             .setOrigin(0.5);

--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -18,6 +18,7 @@ export default class SetupScene extends Phaser.Scene {
 
         const formHtml = `
             <div class="form-container">
+                <h2>New Empire Setup</h2>
                 <div>
                     <label>Empire Name:<br><input type="text" id="empireName" /></label>
                 </div>

--- a/style.css
+++ b/style.css
@@ -1,12 +1,13 @@
 @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;600&display=swap');
 
 html, body {
     margin: 0;
     padding: 0;
     height: 100%;
-    background-color: #000;
-    color: #0ff;
-    font-family: 'Orbitron', sans-serif;
+    background: #0b0f1a;
+    color: #e0e0e0;
+    font-family: 'Orbitron', 'Rajdhani', sans-serif;
 }
 
 #game-container {
@@ -22,11 +23,21 @@ canvas {
 }
 
 .form-container {
-    background: rgba(0, 0, 0, 0.6);
+    width: 80%;
+    max-width: 420px;
+    background: rgba(11, 15, 26, 0.9);
     padding: 20px;
-    border: 2px solid #0ff;
-    color: #0ff;
-    font-family: 'Orbitron', sans-serif;
+    border: 2px solid #00ffe0;
+    border-radius: 8px;
+    box-shadow: 0 0 12px rgba(0, 255, 224, 0.2);
+    color: #e0e0e0;
+    font-family: 'Orbitron', 'Rajdhani', sans-serif;
+}
+.form-container h2 {
+    margin-top: 0;
+    margin-bottom: 16px;
+    color: #00ffe0;
+    text-align: center;
 }
 .form-container label {
     display: block;
@@ -37,16 +48,28 @@ canvas {
     width: 100%;
     margin-top: 4px;
     margin-bottom: 12px;
-    background: #000;
-    color: #0ff;
-    border: 1px solid #0ff;
+    padding: 6px 8px;
+    background: #0b0f1a;
+    color: #e0e0e0;
+    border: 1px solid #00ffe0;
+    border-radius: 4px;
+    transition: box-shadow 0.3s;
 }
 .form-container button {
     display: block;
     margin: 0 auto;
     padding: 8px 20px;
     background: #001020;
-    color: #0ff;
-    border: 1px solid #0ff;
+    color: #00ffe0;
+    border: 1px solid #00ffe0;
+    border-radius: 4px;
     cursor: pointer;
+    transition: box-shadow 0.3s;
+}
+.form-container input:hover,
+.form-container input:focus,
+.form-container select:hover,
+.form-container select:focus,
+.form-container button:hover {
+    box-shadow: 0 0 8px #00ffe0;
 }

--- a/ui/MainMenu.js
+++ b/ui/MainMenu.js
@@ -39,13 +39,14 @@ export default class MainMenu extends Phaser.Scene {
         this.titleText = this.add
             .text(0, 0, 'Stellar Fleet 2D', {
                 fontFamily: 'Orbitron',
-                color: '#0ff',
-                stroke: '#0ff',
+                color: '#00ffe0',
+                stroke: '#00ffe0',
                 strokeThickness: 2,
             })
             .setOrigin(0.5);
 
         this.playButton = createMenuButton(this, 0, 0, 'New Game', () => {
+            this.scene.start('SetupScene');
         });
 
         this.quitButton = createMenuButton(this, 0, 0, 'Quit', () => {


### PR DESCRIPTION
## Summary
- add Rajdhani font and darker background
- make setup form stylish with glow and responsive width
- hook new game button to SetupScene
- ensure accent color uses turquoise

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869a946a18c8325bb16e3f6d74e5806