### PR TITLE
Remove binary icons from PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Prototype Phaser 3 project structure.
 
 Open `index.html` to access the HTML main menu. Clicking **New Game** loads `game.html` which now opens directly on the empire setup form.
+
+## Progressive Web App
+
+The project now includes a `manifest.json` and a service worker so it can be installed and run offline like a standard PWA.

--- a/game.html
+++ b/game.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stellar Fleet 2D</title>
+    <link rel="manifest" href="manifest.json">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&family=Rajdhani:wght@400;600&display=swap" rel="stylesheet">
@@ -14,5 +15,10 @@
 <body>
     <div id="game-container"></div>
     <script type="module" src="main.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('service-worker.js');
+        }
+    </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stellar Fleet 2D</title>
+    <link rel="manifest" href="manifest.json">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&family=Rajdhani:wght@400;600&display=swap" rel="stylesheet">
@@ -17,5 +18,10 @@
         <button class="menu-btn" onclick="window.close()">Quit</button>
     </div>
     <div class="version">v0.1 Alpha</div>
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('service-worker.js');
+        }
+    </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Stellar Fleet 2D",
+  "short_name": "SF2D",
+  "start_url": "index.html",
+  "display": "standalone",
+  "background_color": "#0b0f1a",
+  "theme_color": "#00ffe0"
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,30 @@
+const CACHE_NAME = 'stellar-fleet-cache-v1';
+const ASSETS = [
+  '/',
+  'index.html',
+  'game.html',
+  'main.js',
+  'style.css',
+  'manifest.json',
+  'assets/main menu.png',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- remove binary PNG icons
- update manifest to drop icon references
- stop caching icons in the service worker

## Testing
- `node -v`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a1948eba883259489c76263cd8c3e