### PR TITLE
Add single-page sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stellar-Fleet-2D
 
-Prototype Phaser 3 project structure.
+Prototype Phaser 3 project structured as a **single page application**.
 
 Open `index.html` to access the HTML main menu. Clicking **New Game** now starts the Phaser game directly on the empire setup form without leaving the page.
 
@@ -10,7 +10,7 @@ The project now includes a `manifest.json` and a service worker so it can be ins
 
 ## Main Scene
 
-As the game launches, players are greeted by a sleek, animated main menu interface set against a backdrop of a distant galaxy — stars glimmer, planets rotate slowly, and distant fleets glide silently across the void. The main navigation panel is centered or aligned to the left, depending on the screen layout, and includes the following options:
+As the game launches, players are greeted by a sleek, animated main menu interface set against a backdrop of a distant galaxy — stars glimmer, planets rotate slowly, and distant fleets glide silently across the void. The application works as a **one-page site**: clicking a menu item simply reveals a different section. The main navigation panel includes the following options:
 
 - New Game – Start a fresh campaign. Players can choose a faction, configure galaxy settings (number of systems, AI difficulty, etc.), and name their empire.
 

--- a/index.html
+++ b/index.html
@@ -15,9 +15,21 @@
         <div class="logo"></div>
         <h1 class="title">Stellar Fleet 2D</h1>
         <button id="newGameBtn" class="menu-btn">New Game</button>
+        <button id="codexBtn" class="menu-btn">Codex</button>
+        <button id="creditsBtn" class="menu-btn">Credits</button>
         <button class="menu-btn" onclick="window.close()">Quit</button>
     </div>
-    <div id="game-container"></div>
+    <div id="codex" class="section">
+        <h2>Codex</h2>
+        <p>Welcome to the codex. Here you can find background lore.</p>
+        <button id="backCodex" class="menu-btn">Back</button>
+    </div>
+    <div id="credits" class="section">
+        <h2>Credits</h2>
+        <p>Stellar Fleet 2D Prototype</p>
+        <button id="backCredits" class="menu-btn">Back</button>
+    </div>
+    <div id="game-container" class="section"></div>
     <div class="version">v0.1 Alpha</div>
     <script type="module" src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
     <script type="module">
@@ -25,11 +37,25 @@
 
         const menu = document.getElementById('menu');
         const gameContainer = document.getElementById('game-container');
+        const codex = document.getElementById('codex');
+        const credits = document.getElementById('credits');
+
+        const sections = { menu, game: gameContainer, codex, credits };
+        function showSection(name) {
+            Object.values(sections).forEach(el => (el.style.display = 'none'));
+            sections[name].style.display = 'block';
+        }
+
         document.getElementById('newGameBtn').addEventListener('click', () => {
-            menu.style.display = 'none';
-            gameContainer.style.display = 'block';
+            showSection('game');
             startGame(gameContainer);
         });
+        document.getElementById('codexBtn').addEventListener('click', () => showSection('codex'));
+        document.getElementById('creditsBtn').addEventListener('click', () => showSection('credits'));
+        document.getElementById('backCodex').addEventListener('click', () => showSection('menu'));
+        document.getElementById('backCredits').addEventListener('click', () => showSection('menu'));
+
+        showSection('menu');
 
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('service-worker.js');

--- a/style.css
+++ b/style.css
@@ -80,12 +80,26 @@ body::after {
     z-index: 1;
 }
 
+/* Section containers for one-page navigation */
+.section {
+    width: 100%;
+    height: 100vh;
+    display: none;
+    padding-top: 40px;
+    box-sizing: border-box;
+    text-align: center;
+}
+
+.section h2 {
+    margin-top: 0;
+    color: #00ffe0;
+}
+
 /* Existing game styles */
 #game-container {
     width: 100%;
     height: 100%;
     overflow: hidden;
-    display: none;
 }
 
 canvas {


### PR DESCRIPTION
## Summary
- expand README to mention single page app
- add Codex and Credits sections in `index.html`
- implement section navigation logic
- add `.section` style for one-page layout

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a8def62108325b7c5301fc1e89bbe