### PR TITLE
Add humans civilisation dataclass and logic

### DIFF
--- a/civilisationExample.js
+++ b/civilisationExample.js
@@ -1,0 +1,4 @@
+import humans from './dataclasses/Humans.js';
+import { describeCivilisation } from './logic/civilisationLogic.js';
+
+console.log(describeCivilisation(humans));

--- a/dataclasses/Civilisation.js
+++ b/dataclasses/Civilisation.js
@@ -1,0 +1,10 @@
+export default class Civilisation {
+    constructor(name = '', avatar = '', perks = [], background = '', typeOfGovernment = '', archEnemy = '') {
+        this.name = name;
+        this.avatar = avatar;
+        this.perks = perks;
+        this.background = background;
+        this.typeOfGovernment = typeOfGovernment;
+        this.archEnemy = archEnemy;
+    }
+}

--- a/dataclasses/Humans.js
+++ b/dataclasses/Humans.js
@@ -1,0 +1,12 @@
+import Civilisation from './Civilisation.js';
+
+const humans = new Civilisation(
+    'Humans',
+    'images/avatars/human.png',
+    ['Adaptive Intelligence', 'Rapid Expansion', 'Diplomatic Flexibility'],
+    'Originating from the planet Earth, humans are a highly adaptable species known for their resilience, technological creativity, and turbulent history. They have colonized multiple star systems and often act as mediators or instigators in galactic affairs. Despite their internal divisions, they unite quickly when facing an external threat.',
+    'Federal Republic',
+    'Zelvans'
+);
+
+export default humans;

--- a/logic/civilisationLogic.js
+++ b/logic/civilisationLogic.js
@@ -1,0 +1,21 @@
+/**
+ * Return a formatted description of the civilisation.
+ * @param {Object} civilisation - civilisation dataclass
+ * @returns {string} Summary of the civilisation
+ */
+export function describeCivilisation(civilisation) {
+    const perkList = civilisation.perks.join(', ');
+    return `${civilisation.name} (${civilisation.typeOfGovernment}) - Arch Enemy: ${civilisation.archEnemy}\n` +
+        `${civilisation.background}\nPerks: ${perkList}`;
+}
+
+/**
+ * Add a new perk to the civilisation if not already present.
+ * @param {Object} civilisation - civilisation dataclass
+ * @param {string} perk - perk to add
+ */
+export function addPerk(civilisation, perk) {
+    if (perk && !civilisation.perks.includes(perk)) {
+        civilisation.perks.push(perk);
+    }
+}


### PR DESCRIPTION
## Summary
- add a pure dataclass `Civilisation` for faction data
- add the `Humans` civilisation definition
- implement `describeCivilisation` and `addPerk` helper functions
- include a short example script showing how to describe the human civilisation

## Testing
- `node civilisationExample.js`


------
https://chatgpt.com/codex/tasks/task_e_686a911d400c8325a4f643919abfa076