### PR TITLE
Implement animated menu and load game feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ Hovering over each option triggers subtle UI animations and ambient sounds, rein
 
 ## Setup Scene
 
+The setup form gathers the initial empire information. When the player starts a game this data is stored in `localStorage` so it can be loaded later from the **Load Game** menu.
+
+## Load Game
+
+Selecting **Load Game** displays a simple page showing the last saved empire if one exists. Clicking **Load Last Game** immediately starts the main scene with that saved configuration.
+
+## Animated Background
+
+The main menu now includes a lightweight CSS starfield that scrolls slowly across the screen, providing a subtle sense of motion behind the static galaxy image.
+

--- a/index.html
+++ b/index.html
@@ -15,9 +15,16 @@
         <div class="logo"></div>
         <h1 class="title">Stellar Fleet 2D</h1>
         <button id="newGameBtn" class="menu-btn">New Game</button>
+        <button id="loadGameBtn" class="menu-btn">Load Game</button>
         <button id="codexBtn" class="menu-btn">Codex</button>
         <button id="creditsBtn" class="menu-btn">Credits</button>
         <button class="menu-btn" onclick="window.close()">Quit</button>
+    </div>
+    <div id="loadGame" class="section">
+        <h2>Load Game</h2>
+        <p id="saveInfo">No saved game found.</p>
+        <button id="loadLastBtn" class="menu-btn">Load Last Game</button>
+        <button id="backLoad" class="menu-btn">Back</button>
     </div>
     <div id="codex" class="section">
         <h2>Codex</h2>
@@ -39,21 +46,46 @@
         const gameContainer = document.getElementById('game-container');
         const codex = document.getElementById('codex');
         const credits = document.getElementById('credits');
+        const loadGameSection = document.getElementById('loadGame');
 
-        const sections = { menu, game: gameContainer, codex, credits };
+        const sections = { menu, game: gameContainer, codex, credits, load: loadGameSection };
         function showSection(name) {
             Object.values(sections).forEach(el => (el.style.display = 'none'));
             sections[name].style.display = 'block';
         }
 
+        const saveInfo = document.getElementById('saveInfo');
+        const loadLastBtn = document.getElementById('loadLastBtn');
+
         document.getElementById('newGameBtn').addEventListener('click', () => {
             showSection('game');
             startGame(gameContainer);
+        });
+        document.getElementById('loadGameBtn').addEventListener('click', () => {
+            const data = localStorage.getItem('lastGame');
+            if (data) {
+                const setup = JSON.parse(data);
+                saveInfo.textContent = `Last empire: ${setup.empireName}`;
+                loadLastBtn.disabled = false;
+            } else {
+                saveInfo.textContent = 'No saved game found.';
+                loadLastBtn.disabled = true;
+            }
+            showSection('load');
+        });
+        loadLastBtn.addEventListener('click', () => {
+            const data = localStorage.getItem('lastGame');
+            if (data) {
+                const setup = JSON.parse(data);
+                showSection('game');
+                startGame(gameContainer, setup);
+            }
         });
         document.getElementById('codexBtn').addEventListener('click', () => showSection('codex'));
         document.getElementById('creditsBtn').addEventListener('click', () => showSection('credits'));
         document.getElementById('backCodex').addEventListener('click', () => showSection('menu'));
         document.getElementById('backCredits').addEventListener('click', () => showSection('menu'));
+        document.getElementById('backLoad').addEventListener('click', () => showSection('menu'));
 
         showSection('menu');
 

--- a/main.js
+++ b/main.js
@@ -3,8 +3,14 @@ import MainScene from './scenes/MainScene.js';
 
 let game;
 
-export function startGame(parentId = 'game-container') {
-    if (game) return game;
+export function startGame(parentId = 'game-container', setupData = null) {
+    if (game) {
+        if (setupData) {
+            game.scene.stop('SetupScene');
+            game.scene.start('MainScene', { setupData });
+        }
+        return game;
+    }
 
     const config = {
         type: Phaser.AUTO,
@@ -24,6 +30,11 @@ export function startGame(parentId = 'game-container') {
     };
 
     game = new Phaser.Game(config);
+
+    if (setupData) {
+        game.scene.stop('SetupScene');
+        game.scene.start('MainScene', { setupData });
+    }
 
     window.addEventListener('resize', () => {
         game.scale.resize(window.innerWidth, window.innerHeight);

--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -54,6 +54,7 @@ export default class SetupScene extends Phaser.Scene {
             this.setupData.civilization = this.form.getChildByID('civilization').value;
             this.setupData.leaderName = this.form.getChildByID('leaderName').value;
             this.setupData.leader = this.form.getChildByID('leader').value;
+            localStorage.setItem('lastGame', JSON.stringify(this.setupData));
             this.scene.start('MainScene', { setupData: this.setupData });
         });
 

--- a/style.css
+++ b/style.css
@@ -12,6 +12,31 @@ html, body {
     position: relative;
 }
 
+body::before {
+    content: '';
+    pointer-events: none;
+    position: fixed;
+    inset: 0;
+    background-image:
+        radial-gradient(1px 1px at 20% 30%, #ffffff, transparent),
+        radial-gradient(1px 1px at 40% 70%, #ffffff, transparent),
+        radial-gradient(1px 1px at 60% 40%, #ffffff, transparent),
+        radial-gradient(1px 1px at 80% 80%, #ffffff, transparent);
+    background-size: 800px 800px;
+    animation: starScroll 60s linear infinite;
+    opacity: 0.6;
+    z-index: 0;
+}
+
+@keyframes starScroll {
+    from {
+        transform: translate(0, 0);
+    }
+    to {
+        transform: translate(-200px, -200px);
+    }
+}
+
 body::after {
     content: '';
     pointer-events: none;


### PR DESCRIPTION
## Summary
- add CSS starfield using body::before and keyframes
- allow saving setup data in `localStorage`
- add optional setupData to `startGame` to load saved games
- extend HTML with Load Game section and logic for loading saves
- document new features in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a973c86a08325892e2e4575260ee0