### PR TITLE
Add civilization carousel to setup

### DIFF
--- a/logic/setupLogic.js
+++ b/logic/setupLogic.js
@@ -1,0 +1,104 @@
+/**
+ * Default civilizations displayed in the setup carousel.
+ * @type {{name:string, description:string, image:string}[]}
+ */
+export const defaultCivilizations = [
+  {
+    name: 'Terran',
+    description: 'Hardy settlers from Earth.',
+    image: 'assets/main menu.png'
+  },
+  {
+    name: 'Martian',
+    description: 'Colonists forged on Mars.',
+    image: 'assets/main menu.png'
+  },
+  {
+    name: 'Alien',
+    description: 'Mysterious visitors from afar.',
+    image: 'assets/main menu.png'
+  }
+];
+
+/**
+ * Initialise a swipeable civilization carousel into the given root element.
+ *
+ * @param {HTMLElement} root - container element to populate
+ * @param {{name:string, description:string, image:string}[]} civilizations
+ * @returns {HTMLInputElement} hidden input storing the selected value
+ */
+export function initCivilizationCarousel(root, civilizations = defaultCivilizations) {
+  const container = document.createElement('div');
+  container.className = 'civ-container';
+  const hidden = document.createElement('input');
+  hidden.type = 'hidden';
+  hidden.id = 'civilization';
+  root.appendChild(container);
+  root.appendChild(hidden);
+
+  civilizations.forEach((civ) => {
+    const card = document.createElement('div');
+    card.className = 'civ-card';
+    card.dataset.value = civ.name;
+    card.innerHTML = `
+      <img src="${civ.image}" alt="${civ.name}">
+      <h3>${civ.name}</h3>
+      <p>${civ.description}</p>`;
+    container.appendChild(card);
+  });
+
+  const cards = container.querySelectorAll('.civ-card');
+  if (cards.length) {
+    cards[0].classList.add('selected');
+    hidden.value = cards[0].dataset.value;
+  }
+
+  cards.forEach((card) => {
+    card.addEventListener('click', () => {
+      cards.forEach((c) => c.classList.remove('selected'));
+      card.classList.add('selected');
+      hidden.value = card.dataset.value;
+    });
+  });
+
+  // swipe scrolling behaviour
+  let cardWidth = 0;
+  const first = cards[0];
+  if (first) {
+    const style = getComputedStyle(first);
+    const margin = parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+    cardWidth = first.getBoundingClientRect().width + margin;
+  }
+  let isDown = false;
+  let startX = 0;
+  let scrollStart = 0;
+  const getX = (e) => (e.touches ? e.touches[0].clientX : e.clientX);
+  const onDown = (e) => {
+    isDown = true;
+    startX = getX(e);
+    scrollStart = container.scrollLeft;
+  };
+  const onMove = (e) => {
+    if (!isDown) return;
+    container.scrollLeft = scrollStart + (startX - getX(e));
+    e.preventDefault();
+  };
+  const onUp = () => {
+    if (!isDown) return;
+    isDown = false;
+    if (cardWidth) {
+      const index = Math.round(container.scrollLeft / cardWidth);
+      container.scrollTo({ left: index * cardWidth, behavior: 'smooth' });
+    }
+  };
+  container.addEventListener('mousedown', onDown);
+  container.addEventListener('touchstart', onDown);
+  container.addEventListener('mousemove', onMove);
+  container.addEventListener('touchmove', onMove, { passive: false });
+  window.addEventListener('mouseup', onUp);
+  window.addEventListener('mouseleave', onUp);
+  window.addEventListener('touchend', onUp);
+  window.addEventListener('touchcancel', onUp);
+
+  return hidden;
+}

--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -1,4 +1,5 @@
 import EmpireSetup from '../dataclasses/EmpireSetup.js';
+import { initCivilizationCarousel } from '../logic/setupLogic.js';
 
 export default class SetupScene extends Phaser.Scene {
     constructor() {
@@ -24,11 +25,7 @@ export default class SetupScene extends Phaser.Scene {
                 </div>
                 <div>
                     <label>Civilization:<br>
-                        <select id="civilization">
-                            <option value="Terran">Terran</option>
-                            <option value="Martian">Martian</option>
-                            <option value="Alien">Alien</option>
-                        </select>
+                        <div id="civSelector" class="civ-selector"></div>
                     </label>
                 </div>
                 <div>
@@ -47,6 +44,9 @@ export default class SetupScene extends Phaser.Scene {
             </div>`;
 
         this.form = this.add.dom(width / 2, height / 2).createFromHTML(formHtml);
+
+        const civContainer = this.form.getChildByID('civSelector');
+        initCivilizationCarousel(civContainer);
 
         const startBtn = this.form.getChildByID('startBtn');
         startBtn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -186,3 +186,55 @@ canvas {
 .form-container button:hover {
     box-shadow: 0 0 8px #00ffe0;
 }
+
+/* Civilization carousel */
+.civ-selector {
+    width: 100%;
+    overflow: hidden;
+    margin-bottom: 12px;
+}
+
+.civ-selector .civ-container {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    user-select: none;
+    gap: 10px;
+    padding-bottom: 10px;
+}
+
+.civ-selector .civ-container::-webkit-scrollbar {
+    display: none;
+}
+
+.civ-selector .civ-card {
+    flex: 0 0 80%;
+    max-width: 320px;
+    margin: 0 10px;
+    background: #ffffff;
+    color: #000000;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    text-align: center;
+    scroll-snap-align: center;
+    cursor: pointer;
+}
+
+.civ-selector .civ-card.selected {
+    border: 2px solid #00ffe0;
+}
+
+.civ-selector .civ-card img {
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
+    border-radius: 8px 8px 0 0;
+}
+
+@media (min-width: 600px) {
+    .civ-selector .civ-card {
+        flex-basis: 40%;
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `initCivilizationCarousel` helper for swipeable card selector
- style new civilization carousel
- use carousel in `SetupScene` when choosing civilization

## Testing
- `node --check scenes/SetupScene.js`
- `node --check logic/setupLogic.js`


------
https://chatgpt.com/codex/tasks/task_e_686a9a517ca083259a739a0cf5b694d4