### PR TITLE
Fix mobile centering for setup scene

### DIFF
--- a/style.css
+++ b/style.css
@@ -127,6 +127,7 @@ body::after {
 #game-container {
     width: 100%;
     height: 100vh;
+    height: 100dvh;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -144,6 +145,9 @@ canvas {
 .form-container {
     width: 80%;
     max-width: 420px;
+    max-height: 90vh;
+    max-height: 90dvh;
+    overflow-y: auto;
     background: rgba(11, 15, 26, 0.9);
     padding: 20px;
     border: 2px solid #00ffe0;


### PR DESCRIPTION
## Summary
- ensure game container spans full viewport height on mobile
- keep setup form scrollable on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aa95ec7188325985df99d385adacd