### PR TITLE
Add Zelvan image to swipeable card

### DIFF
--- a/dataclasses/Zelvans.js
+++ b/dataclasses/Zelvans.js
@@ -2,7 +2,7 @@ import Civilisation from './Civilisation.js';
 
 const zelvans = new Civilisation(
   'Zelvans',
-  'assets/main menu.png',
+  'assets/Zelvans.jpg',
   ['Amphibious Physiology', 'Bioluminescent Communication', 'Stealth in Aquatic Environments'],
   'The Zelvans evolved in the deep oceans of the planet Zelvaris. Covered in iridescent scales that shimmer with emotional hues, they built majestic underwater cities powered by geothermal vents. Their society values ritual, tradition, and the spiritual guidance of the Oracles. Contact with surface-dwelling species has led to conflict, especially with the rapidly expanding humans, whose industrial pollution once poisoned a sacred sea trench.',
   'Spiritual Theocracy',


### PR DESCRIPTION
## Summary
- use dedicated Zelvan portrait for swipeable card selections

## Testing
- `npm test` *(fails: package.json not found)*
- `npm run lint` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa97aa2248325a73149db7ca1232c