### PR TITLE
Add Jest-based UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+package-lock.json
+
+# logs
+npm-debug.log*
+
+# Coverage directory
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'jsdom',
+  setupFiles: ['./jest.setup.js']
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,4 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "stellar-fleet-2d",
+  "version": "1.0.0",
+  "description": "Prototype Phaser 3 project structured as a **single page application**.",
+  "main": "main.js",
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.4",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,24 @@
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+import path from 'path';
+
+describe('index.html UI', () => {
+  let document;
+
+  beforeAll(() => {
+    const html = fs.readFileSync(path.resolve('index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    document = dom.window.document;
+  });
+
+  test('contains main menu buttons', () => {
+    const newGame = document.getElementById('newGameBtn');
+    const loadGame = document.getElementById('loadGameBtn');
+    const codex = document.getElementById('codexBtn');
+    const credits = document.getElementById('creditsBtn');
+    expect(newGame).not.toBeNull();
+    expect(loadGame).not.toBeNull();
+    expect(codex).not.toBeNull();
+    expect(credits).not.toBeNull();
+  });
+});

--- a/tests/setupLogic.test.js
+++ b/tests/setupLogic.test.js
@@ -1,0 +1,49 @@
+import { JSDOM } from 'jsdom';
+import { initCivilizationCarousel } from '../logic/setupLogic.js';
+
+/**
+ * Helper to create a DOM with jsdom and expose globals.
+ */
+function createDom() {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+  global.document = dom.window.document;
+  global.window = dom.window;
+  return dom;
+}
+
+describe('initCivilizationCarousel', () => {
+  beforeEach(() => {
+    createDom();
+  });
+
+  test('creates cards and hidden input', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const hidden = initCivilizationCarousel(root, [
+      { name: 'A', description: 'A desc', image: 'a.png' },
+      { name: 'B', description: 'B desc', image: 'b.png' },
+    ]);
+
+    const cards = root.querySelectorAll('.civ-card');
+    expect(cards.length).toBe(2);
+    expect(hidden.id).toBe('civilization');
+    expect(hidden.value).toBe('A');
+    expect(cards[0].classList.contains('selected')).toBe(true);
+  });
+
+  test('clicking card updates selection', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const hidden = initCivilizationCarousel(root, [
+      { name: 'A', description: 'A desc', image: 'a.png' },
+      { name: 'B', description: 'B desc', image: 'b.png' },
+    ]);
+
+    const cards = root.querySelectorAll('.civ-card');
+    cards[1].dispatchEvent(new window.Event('click'));
+    expect(hidden.value).toBe('B');
+    expect(cards[1].classList.contains('selected')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- initialize npm package for ESM
- configure Jest with jsdom test environment
- add basic tests for the main menu and civilization carousel
- add .gitignore to ignore dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686abcfcb8b08325bbc34716929f5305