### PR TITLE
Fix setup screen layout

### DIFF
--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -45,7 +45,10 @@ export default class SetupScene extends Phaser.Scene {
                 </div>
             </div>`;
 
-        this.form = this.add.dom(width / 2, height / 2).createFromHTML(formHtml);
+        this.form = this.add
+            .dom(width / 2, height / 2)
+            .createFromHTML(formHtml)
+            .setOrigin(0.5);
 
         const civContainer = this.form.getChildByID('civSelector');
         initCivilizationCarousel(civContainer);

--- a/style.css
+++ b/style.css
@@ -129,6 +129,8 @@ body::after {
     align-items: center;
     justify-content: center;
     flex-direction: column;
+    width: 100%;
+    height: 100%;
     padding: 20px;
     box-sizing: border-box;
 }
@@ -255,8 +257,9 @@ canvas {
 
 .civ-selector .civ-card img {
     width: 100%;
-    height: 180px;
-    object-fit: cover;
+    max-height: 180px;
+    height: auto;
+    object-fit: contain;
     border-radius: 8px 8px 0 0;
 }
 


### PR DESCRIPTION
## Summary
- center the empire setup form using Phaser's origin
- make the wrapper fill the available space
- ensure civilization card images fit inside the cards

## Testing
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686ac0d7bb688325ba2e6faeecfde5dd