### PR TITLE
Fix mobile layout of carousel

### DIFF
--- a/components/CivilizationSelector.css
+++ b/components/CivilizationSelector.css
@@ -5,27 +5,33 @@
 
 .civ-container {
   display: flex;
-  overflow-x: hidden;
-  touch-action: pan-y;
-  cursor: grab;
-  user-select: none;
+  flex-direction: row;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  gap: 1rem;
+  padding: 1rem 0;
+  width: 100%;
 }
 
 .civ-card {
-  flex: 0 0 80%;
-  max-width: 320px;
-  margin: 0 10px;
-  background: #ffffff;
-  border-radius: 8px;
+  flex: 0 0 85vw;
+  max-width: 400px;
+  margin: 0 auto;
+  box-sizing: border-box;
+  border: 2px solid cyan;
+  border-radius: 15px;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.8);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   text-align: center;
+  scroll-snap-align: center;
 }
 
 .civ-card img {
-  width: 100%;
-  height: 180px;
-  object-fit: cover;
-  border-radius: 8px 8px 0 0;
+  max-width: 100%;
+  height: auto;
+  border-radius: 10px;
 }
 
 .civ-card button {
@@ -40,6 +46,6 @@
 
 @media (min-width: 600px) {
   .civ-card {
-    flex-basis: 40%;
+    flex-basis: 400px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stellar Fleet 2D</title>
     <link rel="manifest" href="manifest.json">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <div class="page-container">
     <div class="menu-container" id="menu">
         <div class="logo"></div>
         <h1 class="title">Stellar Fleet 2D</h1>
@@ -38,6 +39,7 @@
     </div>
     <div id="game-container" class="section"></div>
     <div class="version">v0.1 Alpha</div>
+    </div>
     <script type="module" src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
     <script type="module">
         import { startGame } from './main.js';

--- a/style.css
+++ b/style.css
@@ -4,11 +4,12 @@
 html, body {
     margin: 0;
     padding: 0;
+    width: 100%;
     height: 100%;
     background: #0b0f1a url('assets/main menu.png') no-repeat center/cover;
     color: #e0e0e0;
     font-family: 'Orbitron', 'Rajdhani', sans-serif;
-    overflow: hidden;
+    overflow-x: hidden;
     position: relative;
 }
 
@@ -45,6 +46,18 @@ body::after {
     background: repeating-linear-gradient(180deg, rgba(255,255,255,0.05) 0px, rgba(255,255,255,0.05) 2px, transparent 2px, transparent 4px);
     opacity: 0.1;
     z-index: 2;
+}
+
+/* Layout container to center sections */
+.page-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    min-height: 100vh;
+    padding: 1rem;
+    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 /* Main menu layout */
@@ -212,7 +225,7 @@ canvas {
 
 /* Civilization carousel */
 .civ-selector {
-    --card-width: min(320px, 80vw);
+    --card-width: min(400px, 85vw);
     width: 100%;
     overflow: hidden;
     margin: 0 auto 12px;
@@ -220,12 +233,13 @@ canvas {
 
 .civ-selector .civ-container {
     display: flex;
+    flex-direction: row;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
-    scroll-behavior: smooth;
     -webkit-overflow-scrolling: touch;
-    gap: 10px;
-    padding: 10px calc((100% - var(--card-width)) / 2);
+    gap: 1rem;
+    padding: 1rem 0;
+    width: 100%;
 }
 
 .civ-selector .civ-container::-webkit-scrollbar {
@@ -235,10 +249,13 @@ canvas {
 .civ-selector .civ-card {
     flex: 0 0 var(--card-width);
     max-width: var(--card-width);
-    margin: 0;
-    background: rgba(255, 255, 255, 0.1);
+    margin: 0 auto;
+    box-sizing: border-box;
+    border: 2px solid cyan;
+    border-radius: 15px;
+    padding: 1rem;
+    background: rgba(0, 0, 0, 0.8);
     color: #e0e0e0;
-    border-radius: 8px;
     box-shadow: 0 0 8px rgba(0, 255, 224, 0.2);
     text-align: center;
     scroll-snap-align: center;
@@ -256,11 +273,9 @@ canvas {
 }
 
 .civ-selector .civ-card img {
-    width: 100%;
-    max-height: 180px;
+    max-width: 100%;
     height: auto;
-    object-fit: contain;
-    border-radius: 8px 8px 0 0;
+    border-radius: 10px;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
## Summary
- enforce viewport scale for mobile browsers
- wrap game sections inside a page-container div
- add page-container styles and tweak base body rules
- update civilization carousel styles to center cards and fit mobile screens
- sync React component CSS with same responsive rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ac73b50f083259342a7576a20bc1c