### PR TITLE
Add Perks dataclass

### DIFF
--- a/dataclasses/Perks.js
+++ b/dataclasses/Perks.js
@@ -1,0 +1,9 @@
+export default class Perks {
+    constructor(name = '', bonus = {}, malus = {}, description = '', appliesTo = 'faction') {
+        this.name = name;
+        this.bonus = bonus;
+        this.malus = malus;
+        this.description = description;
+        this.appliesTo = appliesTo; // 'faction' or 'character'
+    }
+}

--- a/tests/perks.test.js
+++ b/tests/perks.test.js
@@ -1,0 +1,23 @@
+import Perks from '../dataclasses/Perks.js';
+
+describe('Perks dataclass', () => {
+  test('initializes with provided values', () => {
+    const bonus = { attack: 5 };
+    const malus = { speed: -2 };
+    const p = new Perks('Warrior Spirit', bonus, malus, 'Boosts attack', 'character');
+    expect(p.name).toBe('Warrior Spirit');
+    expect(p.bonus).toBe(bonus);
+    expect(p.malus).toBe(malus);
+    expect(p.description).toBe('Boosts attack');
+    expect(p.appliesTo).toBe('character');
+  });
+
+  test('uses defaults when no args given', () => {
+    const p = new Perks();
+    expect(p.name).toBe('');
+    expect(p.bonus).toEqual({});
+    expect(p.malus).toEqual({});
+    expect(p.description).toBe('');
+    expect(p.appliesTo).toBe('faction');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `Perks` dataclass for storing bonuses and maluses
- test construction of `Perks`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b615740dc8325bfde54b6ac5f1b39