### PR TITLE
Add leader competence dataclass

### DIFF
--- a/dataclasses/Competence.js
+++ b/dataclasses/Competence.js
@@ -1,0 +1,7 @@
+export default class Competence {
+  constructor(name = '', description = '', effect = '') {
+    this.name = name;
+    this.description = description;
+    this.effect = effect;
+  }
+}

--- a/dataclasses/LeaderCompetences.js
+++ b/dataclasses/LeaderCompetences.js
@@ -1,0 +1,46 @@
+import Competence from './Competence.js';
+
+export const politicalAcumen = new Competence(
+  'Political Acumen',
+  'Ability to navigate power structures, influence policy, and maintain internal stability.',
+  'Boosts internal loyalty, control over factions, and resistance to civil unrest.'
+);
+
+export const economicManagement = new Competence(
+  'Economic Management',
+  'Expertise in resource allocation, production chains, and economic planning.',
+  'Improves resource output, trade efficiency, and infrastructure development.'
+);
+
+export const scientificExpertise = new Competence(
+  'Scientific Expertise',
+  'Knowledge of research processes, innovation, and technological advancement.',
+  'Accelerates research speed, unlocks special projects, improves tech reliability.'
+);
+
+export const militaryCommand = new Competence(
+  'Military Command',
+  'Tactical and strategic skill in leading fleets and managing logistics.',
+  'Enhances fleet effectiveness, initiative in battles, and operational readiness.'
+);
+
+export const diplomaticFinesse = new Competence(
+  'Diplomatic Finesse',
+  'Skill in negotiation, alliance-building, and managing foreign relations.',
+  'Increases treaty success, reduces tensions, and opens diplomatic opportunities.'
+);
+
+export const intelligenceOperations = new Competence(
+  'Intelligence Operations',
+  'Mastery of espionage, counter-intelligence, and covert operations.',
+  'Enables sabotage, information warfare, and resistance to enemy infiltration.'
+);
+
+export default [
+  politicalAcumen,
+  economicManagement,
+  scientificExpertise,
+  militaryCommand,
+  diplomaticFinesse,
+  intelligenceOperations
+];

--- a/tests/competence.test.js
+++ b/tests/competence.test.js
@@ -1,0 +1,14 @@
+import { politicalAcumen, economicManagement, scientificExpertise, militaryCommand, diplomaticFinesse, intelligenceOperations } from '../dataclasses/LeaderCompetences.js';
+
+describe('Leader competences', () => {
+  test('politicalAcumen has expected properties', () => {
+    expect(politicalAcumen.name).toBe('Political Acumen');
+    expect(politicalAcumen.description.length).toBeGreaterThan(0);
+    expect(politicalAcumen.effect.length).toBeGreaterThan(0);
+  });
+
+  test('all competences are exported', () => {
+    const competences = [politicalAcumen, economicManagement, scientificExpertise, militaryCommand, diplomaticFinesse, intelligenceOperations];
+    expect(competences.every(c => c instanceof Object)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `Competence` dataclass to hold skill data
- define several leader competences
- test competence exports

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b6162ad848325966d4586021298dc