### PR TITLE
Refine civilization selector layout

### DIFF
--- a/components/CivilizationSelector.css
+++ b/components/CivilizationSelector.css
@@ -15,8 +15,8 @@
 }
 
 .civ-card {
-  flex: 0 0 85vw;
-  max-width: 400px;
+  flex: 0 0 68vw;
+  max-width: 320px;
   margin: 0 auto;
   box-sizing: border-box;
   border: 2px solid cyan;
@@ -46,6 +46,6 @@
 
 @media (min-width: 600px) {
   .civ-card {
-    flex-basis: 400px;
+    flex-basis: 320px;
   }
 }

--- a/style.css
+++ b/style.css
@@ -318,7 +318,7 @@ canvas {
 
 /* Civilization carousel */
 .civ-selector {
-    --card-width: min(300px, 75vw);
+    --card-width: min(240px, 60vw);
     width: 100%;
     overflow: hidden;
     margin: 0 auto 12px;
@@ -374,7 +374,7 @@ canvas {
     max-width: 100%;
     height: auto;
     border-radius: 6px;
-    aspect-ratio: 4 / 3;
+    object-fit: contain;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
## Summary
- shrink civilization cards by 20%
- keep image aspect ratio without stretching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bce852dc883258fd9a36ad1333f9b