### PR TITLE
Add swipe pagination dots

### DIFF
--- a/logic/setupLogic.js
+++ b/logic/setupLogic.js
@@ -28,11 +28,14 @@ export const defaultCivilizations = [
 export function initCivilizationCarousel(root, civilizations = defaultCivilizations) {
   const container = document.createElement('div');
   container.className = 'civ-container';
+  const dotsWrapper = document.createElement('div');
+  dotsWrapper.className = 'civ-dots';
   const hidden = document.createElement('input');
   hidden.type = 'hidden';
   hidden.id = 'civilization';
   root.appendChild(container);
   root.appendChild(hidden);
+  root.appendChild(dotsWrapper);
 
   civilizations.forEach((civ) => {
     const card = document.createElement('div');
@@ -43,19 +46,29 @@ export function initCivilizationCarousel(root, civilizations = defaultCivilizati
       <h3>${civ.name}</h3>
       <p>${civ.description}</p>`;
     container.appendChild(card);
+    const dot = document.createElement('span');
+    dot.className = 'civ-dot';
+    dotsWrapper.appendChild(dot);
   });
 
   const cards = container.querySelectorAll('.civ-card');
+  const dots = dotsWrapper.querySelectorAll('.civ-dot');
   if (cards.length) {
     cards[0].classList.add('selected');
     hidden.value = cards[0].dataset.value;
+    dots[0].classList.add('active');
   }
 
-  cards.forEach((card) => {
+  const updateDots = (index) => {
+    dots.forEach((d, i) => d.classList.toggle('active', i === index));
+  };
+
+  cards.forEach((card, idx) => {
     card.addEventListener('click', () => {
       cards.forEach((c) => c.classList.remove('selected'));
       card.classList.add('selected');
       hidden.value = card.dataset.value;
+      updateDots(idx);
     });
   });
 
@@ -72,6 +85,8 @@ export function initCivilizationCarousel(root, civilizations = defaultCivilizati
       }
     });
     cards.forEach((c) => c.classList.toggle('active', c === active));
+    const index = Array.from(cards).indexOf(active);
+    if (index >= 0) updateDots(index);
   };
 
   container.addEventListener('scroll', () => requestAnimationFrame(updateActive));

--- a/style.css
+++ b/style.css
@@ -378,6 +378,27 @@ canvas {
     object-fit: contain;
 }
 
+.civ-selector .civ-dots {
+    text-align: center;
+    margin-top: var(--space-sm);
+}
+
+.civ-selector .civ-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    background: var(--color-text);
+    border-radius: 50%;
+    opacity: 0.4;
+    margin: 0 4px;
+    transition: opacity var(--transition-fast), background var(--transition-fast);
+}
+
+.civ-selector .civ-dot.active {
+    background: var(--color-primary);
+    opacity: 1;
+}
+
 @media (min-width: 600px) {
     .civ-selector .civ-card {
         flex-basis: var(--card-width);

--- a/tests/setupLogic.test.js
+++ b/tests/setupLogic.test.js
@@ -30,6 +30,10 @@ describe('initCivilizationCarousel', () => {
     expect(hidden.id).toBe('civilization');
     expect(hidden.value).toBe('A');
     expect(cards[0].classList.contains('selected')).toBe(true);
+
+    const dots = root.querySelectorAll('.civ-dot');
+    expect(dots.length).toBe(2);
+    expect(dots[0].classList.contains('active')).toBe(true);
   });
 
   test('clicking card updates selection', () => {
@@ -42,8 +46,10 @@ describe('initCivilizationCarousel', () => {
     ]);
 
     const cards = root.querySelectorAll('.civ-card');
+    const dots = root.querySelectorAll('.civ-dot');
     cards[1].dispatchEvent(new window.Event('click'));
     expect(hidden.value).toBe('B');
     expect(cards[1].classList.contains('selected')).toBe(true);
+    expect(dots[1].classList.contains('active')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add dot pagination styles for the civilization selector
- create pagination dot elements in `initCivilizationCarousel`
- ensure dots track active card and selection
- test carousel dot behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c236899e883258269a9fddd45f019