### PR TITLE
Simplify empire setup UI

### DIFF
--- a/logic/setupLogic.js
+++ b/logic/setupLogic.js
@@ -43,8 +43,7 @@ export function initCivilizationCarousel(root, civilizations = defaultCivilizati
     card.dataset.value = civ.name;
     card.innerHTML = `
       <img src="${civ.image}" alt="${civ.name}">
-      <h3>${civ.name}</h3>
-      <p>${civ.description}</p>`;
+      <h3>${civ.name}</h3>`;
     container.appendChild(card);
     const dot = document.createElement('span');
     dot.className = 'civ-dot';

--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -9,26 +9,11 @@ export function showSetupScene(container, onStart) {
       <div class="form-container">
         <h2>New Empire Setup</h2>
         <div>
-          <label>Empire Name:<br><input type="text" id="empireName" /></label>
-        </div>
-        <div>
           <label>Civilization:<br>
             <div id="civSelector" class="civ-selector"></div>
           </label>
         </div>
-        <div>
-          <label>Leader Name:<br><input type="text" id="leaderName" /></label>
-        </div>
-        <div>
-          <label>Leader Type:<br>
-            <select id="leader">
-              <option value="Admiral">Admiral</option>
-              <option value="Overlord">Overlord</option>
-              <option value="Commander">Commander</option>
-            </select>
-          </label>
-        </div>
-        <button id="startBtn">Start Game</button>
+        <button id="startBtn" class="next-btn" aria-label="Suivant">&rarr;</button>
       </div>
     </div>`;
 
@@ -39,10 +24,7 @@ export function showSetupScene(container, onStart) {
 
   const startBtn = container.querySelector('#startBtn');
   startBtn.addEventListener('click', () => {
-    setupData.empireName = container.querySelector('#empireName').value;
     setupData.civilization = container.querySelector('#civilization').value;
-    setupData.leaderName = container.querySelector('#leaderName').value;
-    setupData.leader = container.querySelector('#leader').value;
     localStorage.setItem('lastGame', JSON.stringify(setupData));
     if (onStart) onStart(setupData);
   });

--- a/style.css
+++ b/style.css
@@ -309,6 +309,16 @@ canvas {
     cursor: pointer;
     transition: box-shadow var(--transition-fast);
 }
+.next-btn {
+    background: none;
+    border: none;
+    font-size: 2rem;
+    color: var(--color-primary);
+    margin-top: var(--space-md);
+}
+.next-btn:hover {
+    transform: scale(1.1);
+}
 .form-container input:hover,
 .form-container input:focus,
 .form-container select:hover,


### PR DESCRIPTION
## Summary
- trim civilization cards to show only image and name
- reduce the empire setup form to only civilization selection
- add a minimal arrow button for progressing

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c26750d7c832597de63d8927055fc