### PR TITLE
Center civilization carousel

### DIFF
--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -6,15 +6,8 @@ export function showSetupScene(container, onStart) {
 
   const formHtml = `
     <div class="setup-wrapper">
-      <div class="form-container">
-        <h2>New Empire Setup</h2>
-        <div>
-          <label>Civilization:<br>
-            <div id="civSelector" class="civ-selector"></div>
-          </label>
-        </div>
-        <button id="startBtn" class="next-btn" aria-label="Suivant">&rarr;</button>
-      </div>
+      <div id="civSelector" class="civ-selector"></div>
+      <button id="startBtn" class="next-btn" aria-label="Suivant">&rarr;</button>
     </div>`;
 
   container.innerHTML = formHtml;


### PR DESCRIPTION
## Summary
- simplify setup scene markup so only the carousel and start button appear
- keep layout centered using existing `setup-wrapper`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c288074648325b64d235a564853a6