### PR TITLE
Fix React links

### DIFF
--- a/components/CivilizationSelector.js
+++ b/components/CivilizationSelector.js
@@ -1,5 +1,9 @@
-import React, { useState, useEffect } from 'react';
 import './CivilizationSelector.css';
+
+// React is loaded globally from a CDN in index.html. Use the global
+// variables instead of ESM imports so the module works without bundling.
+const React = window.React;
+const { useState, useEffect } = React;
 
 /**
  * Simple carousel showing civilization cards.

--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -1,8 +1,11 @@
 import EmpireSetup from '../dataclasses/EmpireSetup.js';
 import { defaultCivilizations } from '../logic/setupLogic.js';
-import React from 'react';
-import { createRoot } from 'react-dom/client';
 import CivilizationSelector from '../components/CivilizationSelector.js';
+
+// Use global React/ReactDOM loaded via CDN instead of ESM imports so
+// the module works when opened directly in the browser.
+const React = window.React;
+const { createRoot } = window.ReactDOM;
 
 export function showSetupScene(container, onStart) {
   const setupData = new EmpireSetup();


### PR DESCRIPTION
## Summary
- move React to global usage in CivilizationSelector and SetupScene

## Testing
- `npm test --silent` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_686c9a7385d483259e777984f0452b61