### PR TITLE
Handle missing React in offline mode

### DIFF
--- a/scenes/SetupScene.js
+++ b/scenes/SetupScene.js
@@ -3,11 +3,18 @@ import { defaultCivilizations } from '../logic/setupLogic.js';
 import CivilizationSelector from '../components/CivilizationSelector.js';
 
 // Use global React/ReactDOM loaded via CDN instead of ESM imports so
-// the module works when opened directly in the browser.
-const React = window.React;
-const { createRoot } = window.ReactDOM;
+// the module works when opened directly in the browser. If those
+// globals are missing (e.g. offline), show a helpful error message.
+let React = window.React;
+let createRoot = window.ReactDOM && window.ReactDOM.createRoot;
 
 export function showSetupScene(container, onStart) {
+  if (!React || !createRoot) {
+    container.innerHTML =
+      '<p class="error">React n\'a pas pu \u00eatre charg\u00e9. ' +
+      'V\u00e9rifiez votre connexion internet.</p>';
+    return;
+  }
   const setupData = new EmpireSetup();
 
   const formHtml = `

--- a/scenes/domGame.js
+++ b/scenes/domGame.js
@@ -6,6 +6,11 @@ export function startGame(parent = 'game-container', setupData = null) {
   if (!container) return;
   container.innerHTML = '';
 
+  if (!window.React || !window.ReactDOM) {
+    container.textContent = 'React required to run the game. Please check your connection.';
+    return;
+  }
+
   if (setupData) {
     showMainScene(container, { setupData });
   } else {

--- a/style.css
+++ b/style.css
@@ -460,3 +460,11 @@ canvas {
     }
 }
 
+.error {
+    color: red;
+    font-weight: bold;
+    text-align: center;
+    padding: var(--space-lg);
+}
+
+


### PR DESCRIPTION
## Summary
- detect failed React loading in StartGame and SetupScene
- show an error message if the CDN scripts are unavailable
- add simple `.error` style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ca1aac610832591184323e1245dac